### PR TITLE
Support to Integer unification for Ruby 2.4

### DIFF
--- a/lib/gri/mmsgpack.rb
+++ b/lib/gri/mmsgpack.rb
@@ -1,6 +1,6 @@
 # coding: us-ascii
 
-class Fixnum
+class Integer
   def to_msgpack
     if (self >= -32 and self <= 127)
       [self].pack('c')
@@ -9,12 +9,6 @@ class Fixnum
     else
       "\xcf"+[(self>>32), (self&0xffffffff)].pack('N2')
     end
-  end
-end
-
-class Bignum
-  def to_msgpack
-    "\xcf"+[(self>>32), (self&0xffffffff)].pack('N2')
   end
 end
 


### PR DESCRIPTION
I get Deprecation warnings with Ruby 2.4, also `test/test_mmsgpack.rb` fail.

```
[master]$ rbenv shell 2.4.3 && ruby test/test_mmsgpack.rb
lib/gri/mmsgpack.rb:3: warning: constant ::Fixnum is deprecated
lib/gri/mmsgpack.rb:15: warning: constant ::Bignum is deprecated

Started
F
=======================================================================================
Failure: test_mmsgpack(TestMMsgpack)
test/test_mmsgpack.rb:8:in `eq'
test/test_mmsgpack.rb:13:in `test_mmsgpack'
     10:
     11:   def test_mmsgpack
     12:     eq 1
  => 13:     eq -1
     14:     eq 0x7fffffff
     15:     eq 1000
     16:     eq 2000000000
<-1> expected but was
<18446744073709551615>

diff:
? -18446744073709551615
=======================================================================================


Finished in 0.001778 seconds.
---------------------------------------------------------------------------------------
1 tests, 2 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
0% passed
---------------------------------------------------------------------------------------
```

I fixed it by add `Integer#to_msgpack`.

```
[integer_unification] $ rbenv shell 2.4.3 && ruby test/test_mmsgpack.rb
Loaded suite test/test_mmsgpack
Started
.

Finished in 0.000524 seconds.
--------------------------------------------------------------------------------------------
1 tests, 10 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------

```

```
[integer_unification] $ rbenv shell 2.3.6 && ruby test/test_mmsgpack.rb
Loaded suite test/test_mmsgpack
Started
.

Finished in 0.000516 seconds.
--------------------------------------------------------------------------------------------
1 tests, 10 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------
```