### PR TITLE
Fix TypeError on suppress_veth plugin

### DIFF
--- a/lib/gri/plugin/suppress_veth.rb
+++ b/lib/gri/plugin/suppress_veth.rb
@@ -5,8 +5,8 @@ GRI::DEFS['interfaces'].update :ignore? => proc {|record|
   :exclude? => proc {|record|
   record['ifOperStatus'].to_i != 1 or
     record['ifSpeed'].to_i == 0 or
-    (Integer(record['ifInOctets']) == 0 and
-     Integer(record['ifOutOctets']) == 0) or
+    (record['ifInOctets'].to_i == 0 and
+     record['ifOutOctets'].to_i == 0) or
     /(^(|Loopback|Null|Async|lo)\d+)|(^veth\w)|cef layer|atm subif/ ===
     record['ifDescr']
 },


### PR DESCRIPTION
TypeError is raised when `record['ifInOctets']` or `record['ifOutOctets']` is **nil** .

So, I used the **to_i** method instead of the **Integer()** method.  
Because `nil.to_i` does not raise an exception and just returns **0**.

I have been using it with this patch for over 2 years and have had no problems.
