### PR TITLE
Limit rack version to less than 3

### DIFF
--- a/gri.gemspec
+++ b/gri.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency "msgpack"
-  s.add_runtime_dependency "rack"
+  s.add_runtime_dependency "rack", '< 3'
 end


### PR DESCRIPTION
This gem depends on the Rack gem.

The recent release of Rack3, **Rack::Handler** has been separated into a separate gem.   
Therefore, I have confirmed that this gem does not work with Rack3.

It may be the right way which is introduce the rackup gem to use **Rackup::Handler**, but since this gem was probably designed in the Rack2 era, I thought it would be safer to use Rack2 for the moment.